### PR TITLE
Fix sidebar footer logo scaling bug

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -11,7 +11,7 @@
     {{ footer_custom }}
 
     {% if site.last_edit_timestamp or site.gh_edit_link %}
-      <div class="d-flex mt-2">
+      <div class="d-flex mt-5">
         {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
           <p class="text-small text-grey-dk-000 mb-0 mr-2">
             Page last modified: <span class="d-inline-block">{{ page.last_modified_date | date: site.last_edit_time_format }}</span>.

--- a/_includes/components/sidebar.html
+++ b/_includes/components/sidebar.html
@@ -30,6 +30,6 @@
       {% assign color_scheme = "light" %}
     {% endif %}
 
-    {{site.title}} is a member of <div><a href="https://acm.illinois.edu"><img style="width: 50%;" src="/assets/images/acm-wordmark-{{ color_scheme }}.png"/></a></div>.
+    {{site.title}} is a member of <div><a href="https://acm.illinois.edu"><img style="width: 50%;" src="/assets/images/acm-wordmark-{{ color_scheme }}.png"/></a></div>
   </footer>
 </div>

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,5 +1,5 @@
 {%- if site.footer_content -%}
   <p class="text-small text-grey-dk-100 mb-0">{{ site.footer_content }}</p>
 {%- else -%}
-  <p class="text-small text-grey-dk-100 mb-0">Copyright &copy; {{ site.time | date: '%Y' }} by {{ site.title }}, a member of ACM@UIUC.</p>
+  <p class="text-small text-grey-dk-100 mb-0">Copyright &copy; {{ site.time | date: '%Y' }} by {{ site.title }}, a member of <a href="https://acm.illinois.edu">ACM@UIUC</a>.</p>
 {%- endif -%}

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -54,15 +54,15 @@
     }
   }
 
-  // Don't display the sidebar footer when the sidebar is gone, since
-  // it says the same thing as the other footer
   .site-footer {
-    display: none;
-
-    @include mq(md) {
-      display: block;
+    img {
+      max-width: 100px;
+      @include mq(md) {
+          max-width: none;
+      }
     }
   }
+
 }
 
 .main {

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -53,6 +53,16 @@
       }
     }
   }
+
+  // Don't display the sidebar footer when the sidebar is gone, since
+  // it says the same thing as the other footer
+  .site-footer {
+    display: none;
+
+    @include mq(md) {
+      display: block;
+    }
+  }
 }
 
 .main {


### PR DESCRIPTION
Note that in the default template the two footers say pretty much the same thing, but one can be customized